### PR TITLE
Change from `dig` to `hostname`

### DIFF
--- a/wg-debian-server-up.sh
+++ b/wg-debian-server-up.sh
@@ -25,9 +25,6 @@ sudo modprobe wireguard
 echo ----------------------------------------------------------install qrencode
 sudo apt install -y qrencode
 
-echo ----------------------------------------------------------install dnsutils
-sudo apt install -y dnsutils
-
 echo -------------------------------------------------- download wg-genconfig.sh
 cd "${working_dir}" &&
 wget https://raw.githubusercontent.com/drew2a/wireguard/master/wg-genconf.sh

--- a/wg-genconf.sh
+++ b/wg-genconf.sh
@@ -2,8 +2,15 @@
 # usage:
 #     wg-genconf.sh [<number_of_clients> [<server_public_ip>]]
 
+set -e # exit when any command fails
+set -x # enable print all commands
+
 clients_count=${1:-10}
-server_ip=${2:-$(dig @resolver1.opendns.com ANY myip.opendns.com +short)}
+
+server_ip=${2}
+if [ -z "$server_ip" ]; then
+  server_ip=$(hostname -I | awk '{print $1;}') # get only first hostname
+fi
 
 server_private_key=$(wg genkey)
 server_public_key=$(echo "${server_private_key}" | wg pubkey)

--- a/wg-ububtu-server-up.sh
+++ b/wg-ububtu-server-up.sh
@@ -12,8 +12,7 @@ mkdir -p "${working_dir}"
 mkdir -p "/etc/wireguard"
 
 echo ---------------------------------------------------------update and upgrade
-sudo apt update -y
-sudo apt upgrade -y
+sudo apt update -y && sudo apt upgrade -y
 
 echo ------------------------------------------------------install linux headers
 sudo apt install -y linux-headers-"$(uname -r)"
@@ -27,7 +26,6 @@ sudo apt install -y software-properties-common
 echo ---------------------------------------------------------install wireguard
 sudo apt install -y wireguard
 sudo modprobe wireguard
-
 
 echo ----------------------------------------------------------install qrencode
 sudo apt install -y qrencode


### PR DESCRIPTION
### Problem: 

Command `dig @resolver1.opendns.com ANY myip.opendns.com +short` does not return an IP.

### Solution

Use `hostname -I` instead of `dig`

### Checked VPS

* DigitalOcean
* Vultr 

### Checked OS

* Ubuntu 18 
* Ubuntu 20
* Debian 9