### PR TITLE
Feature/disable unbound

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,29 @@ sudo: required
 git:
   depth: 1
 
-matrix:
+jobs:
   include:
     - os: linux
       dist: bionic # ubuntu 18.04
+      env: UBUNTU_18_04=
+      script: sudo ${TRAVIS_BUILD_DIR}/wg-ubuntu-server-up.sh --no-reboot
+
     - os: linux
       dist: focal # ubuntu 20.04
+      env: UBUNTU_20_04=
+      script: sudo ${TRAVIS_BUILD_DIR}/wg-ubuntu-server-up.sh --no-reboot
 
-env:
-  global:
-    - WG_SCRIPT_DISABLE_REBOOT=on
+    - os: linux
+      dist: focal # ubuntu 20.04
+      env: UBUNTU_20_04= NO_UNBOUND=
+      script: sudo ${TRAVIS_BUILD_DIR}/wg-ubuntu-server-up.sh --no-reboot --no-unbound
+
+    - os: linux
+      dist: focal # ubuntu 20.04
+      env: UBUNTU_20_04= NO_UNBOUND= CLIENTS=1
+      script: sudo ${TRAVIS_BUILD_DIR}/wg-ubuntu-server-up.sh --no-reboot --no-unbound --clients=1
 
 install:
   # enable ipv6
   - sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
 
-script:
-  - sudo ${TRAVIS_BUILD_DIR}/wg-ubuntu-server-up.sh

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Medium article: [How to deploy WireGuard node on a DigitalOcean's droplet](https
 ## Quick Start
 
 ### Ubuntu
+
 ```bash
 wget https://raw.githubusercontent.com/drew2a/wireguard/master/wg-ubuntu-server-up.sh
 
@@ -54,8 +55,15 @@ This script:
 ### Usage
 
 ```bash
-wg-ubuntu-server-up.sh [<number_of_clients>]
+wg-ubuntu-server-up.sh [--clients=<clients_count>] [--no-reboot] [--no-unbound]
 ```
+
+Options:
+
+* `--clients=<clients_count>` how many client's configs will be created
+* `--no-unbound` disables Unbound server installation (1.1.1.1 will be used as
+   a default DNS for client's configs)
+* `--no-reboot` disables rebooting at the end of the script execution
 
 ### Example of usage
 
@@ -64,12 +72,13 @@ wg-ubuntu-server-up.sh [<number_of_clients>]
 ```
 
 ```bash
-./wg-ubuntu-server-up.sh 10
+./wg-ubuntu-server-up.sh --clients=10
 ```
 
 ## wg-debian-server-up.sh
 
-This script works the same way, that `wg-ubuntu-server-up.sh` do.
+This script works the same way and with the same options, that
+`wg-ubuntu-server-up.sh` do.
 
 ## wg-genconf.sh
 
@@ -86,8 +95,15 @@ Install [WireGuard](https://www.wireguard.com) if it's not installed.
 ### Usage
 
 ```bash
-./wg-genconf.sh [<number_of_clients> [<server_public_ip>]]
+./wg-genconf.sh [<number_of_clients> [<dns_ip> [<server_public_ip>]]]
 ```
+
+Where:
+
+* `number_of_clients` how many client's configs will be generated
+* `dns_ip` the script should use this IP as a DNS address
+* `server_public_ip` the script should use this IP as a server address
+
 
 ### Example of usage:
 
@@ -100,5 +116,9 @@ Install [WireGuard](https://www.wireguard.com) if it's not installed.
 ```
 
 ```bash
-./wg-genconf.sh 10 157.245.73.253 
+./wg-genconf.sh 10 1.1.1.1
+```
+
+```bash
+./wg-genconf.sh 10 1.1.1.1 157.245.73.253
 ```

--- a/wg-genconf.sh
+++ b/wg-genconf.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
 # usage:
-#     wg-genconf.sh [<number_of_clients> [<server_public_ip>]]
+#     wg-genconf.sh [<number_of_clients> [<dns_ip> [<server_public_ip>]]]
 
 set -e # exit when any command fails
 set -x # enable print all commands
 
+#  clients' count
 clients_count=${1:-10}
 
-server_ip=${2}
+# dns ip
+dns_ip=${2:-10.0.0.1}
+
+# server ip
+server_ip=${3}
 if [ -z "$server_ip" ]; then
   server_ip=$(hostname -I | awk '{print $1;}') # get only first hostname
 fi
+
+
+
 
 server_private_key=$(wg genkey)
 server_public_key=$(echo "${server_private_key}" | wg pubkey)
@@ -59,7 +67,7 @@ do
 PrivateKey = ${client_private_key}
 ListenPort = 51820
 Address = ${client_ip}
-DNS = 10.0.0.1
+DNS = ${dns_ip}
 
 [Peer]
 PublicKey = ${server_public_key}

--- a/wg-ubuntu-server-up.sh
+++ b/wg-ubuntu-server-up.sh
@@ -1,23 +1,31 @@
 #!/usr/bin/env bash
 # usage:
-#     wg-ubuntu-server-up.sh [<number_of_clients>]
+#     wg-ubuntu-server-up.sh [--clients=<clients_count>] [--no-reboot] [--no-unbound]
 #
-#     To disable automatic reboot at the end of the execution:
-#     ```
-#       export WG_SCRIPT_DISABLE_REBOOT=on
-#     ```
 
 set -e # exit when any command fails
 set -x # enable print all commands
 
-# check is root
+# constants:
+working_dir="$HOME/wireguard"
+
+# inputs:
+clients=10
+reboot_enabled=true
+unbound_enabled=true
+
+for arg in "$@"
+do
+  [[ "${arg}" == "--no-reboot" ]] && reboot_enabled=
+  [[ "${arg}" == "--no-unbound" ]] && unbound_enabled=
+  [[ "${arg}" == "--clients="* ]] && clients=${arg#*=}
+done
+
+# check a user is root
 if [ "$(id -u)" != 0 ]; then
   echo Please, run the script as root: \"sudo ./wg-ubuntu-server-up.sh\"
   exit 1
 fi
-
-clients_count=${1:-10}
-working_dir="$HOME/wireguard"
 
 mkdir -p "${working_dir}"
 mkdir -p "/etc/wireguard"
@@ -46,8 +54,15 @@ cd "${working_dir}" &&
 wget https://raw.githubusercontent.com/drew2a/wireguard/master/wg-genconf.sh
 chmod +x ./wg-genconf.sh
 
-echo ----------------------generate configurations for "${clients_count}" clients
-./wg-genconf.sh "${clients_count}"
+echo ----------------------generate configurations for "${clients}" clients
+if [[ ${unbound_enabled} ]]; then
+   # use the wireguard server as a DNS resolver
+  ./wg-genconf.sh "${clients}"
+else
+  # use the cloudflare as a DNS resolver
+  ./wg-genconf.sh "${clients}" "1.1.1.1"
+fi
+
 
 echo -----------------------------------move server\'s config to /etc/wireguard/
 mv -v ./wg0.conf \
@@ -80,16 +95,17 @@ apt install -y iptables-persistent
 systemctl enable netfilter-persistent
 netfilter-persistent save
 
-echo ---------------------------------------------install and configure unbound
-apt install -y unbound unbound-host
+if [[ ${unbound_enabled} ]]; then
+  echo ---------------------------------------------install and configure unbound
+  apt install -y unbound unbound-host
 
-mkdir -p /var/lib/unbound
-curl -o /var/lib/unbound/root.hints https://www.internic.net/domain/named.cache
-echo 'curl -o /var/lib/unbound/root.hints https://www.internic.net/domain/named.cache' > /etc/cron.monthly/curl_root_hints.sh
-chmod +x /etc/cron.monthly/curl_root_hints.sh
+  mkdir -p /var/lib/unbound
+  curl -o /var/lib/unbound/root.hints https://www.internic.net/domain/named.cache
+  echo 'curl -o /var/lib/unbound/root.hints https://www.internic.net/domain/named.cache' > /etc/cron.monthly/curl_root_hints.sh
+  chmod +x /etc/cron.monthly/curl_root_hints.sh
 
 
-cat > /etc/unbound/unbound.conf << ENDOFFILE
+  cat > /etc/unbound/unbound.conf << ENDOFFILE
 server:
     num-threads: 4
     # disable logs
@@ -136,16 +152,17 @@ server:
     private-address: 10.0.0.0/24
 ENDOFFILE
 
-# give root ownership of the Unbound config
-chown -R unbound:unbound /var/lib/unbound
+  # give root ownership of the Unbound config
+  chown -R unbound:unbound /var/lib/unbound
 
-# disable systemd-resolved
-systemctl stop systemd-resolved
-systemctl disable systemd-resolved
+  # disable systemd-resolved
+  systemctl stop systemd-resolved
+  systemctl disable systemd-resolved
 
-# enable Unbound in place of systemd-resovled
-systemctl enable unbound
-systemctl start unbound
+  # enable Unbound in place of systemd-resovled
+  systemctl enable unbound
+  systemctl start unbound
+fi
 
 # show wg
 wg show
@@ -166,7 +183,7 @@ echo
 
 # if WG_SCRIPT_DISABLE_REBOOT is not set, then
 # reboot to make changes effective
-if [ -z "${WG_SCRIPT_DISABLE_REBOOT}" ]; then
+if [[ ${reboot_enabled} ]]; then
   echo All done, reboot...
   reboot
 fi


### PR DESCRIPTION
### Problem 

There is a request to run scripts without installing an Unbound server.

### Solution

Options `--no-unbound` is added:

```bash
sudo ./wg-ubuntu-server-up.sh --no-unbound
```

or

```bash
sudo ./wg-debian-server-up.sh --no-unbound
```

In case this option is set then no Unbound server will be installed. 

As a DNS address by-default, `1.1.1.1` will be used.

### Checked VPS

* DO

### Checked OS

* Ubuntu 20.04 
* Ubuntu 20.04 (--no-unbound)
* Debian 10
* Debian 10 (--no-unbound)